### PR TITLE
Shorten OIDC role name

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -50,7 +50,7 @@ jobs:
       with:
         aws-region: ${{ env.AWS_REGION }}
         role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
-        role-session-name: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+        role-session-name: GHA-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
         role-duration-seconds: 3600
     - name: Build and Upload AMI
       run: |


### PR DESCRIPTION
The role name must not exceed 64 chars, but is currently 66.

Depends on Sage-Bionetworks-IT/organizations-infra#1108